### PR TITLE
chore: doc updates

### DIFF
--- a/Config.toml.example
+++ b/Config.toml.example
@@ -23,5 +23,5 @@ room_creation_throughput = 20
 # Update the client's homeserver URL with the discovery information present in the login response, if any.
 # In case of localhost, you probably want to set as false.
 respect_login_well_known = true
-# Count of useres to work with (create/erase)
+# Count of users to work with (create/erase)
 user_count = 3000

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ rustup component add llvm-tools-preview
 brew install michaeleisel/zld/zld
 ```
 
+#### Notes
+- You might need to install XCode first from the App Store (not the Command Line Tools)
+- If Command Line Tools where already present in the system you might need to first 1) make sure XCode is in the `/Applications` directory and not the user apps one and 2) point xcode-select to the actual XCode app by using: `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
+
 ## Quick start
 
 1. First of all, copy the [`Config.toml.example`](Config.toml.example) file in the root directory of the project to `Config.toml`, this file will be ignored in the git repository.


### PR DESCRIPTION
- Fixes a typo in `Config.toml.example`
- Adds documentation on how to configure and fix potential issue while trying to install the `zld` linker in MacOS