### PR TITLE
fix: missing rooms on existing friendships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 /target
 /output
 Config.toml
+users_test.json
+users.local.json
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,70 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'matrix_load_testing_tool'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=matrix-load-testing-tool"
+                ],
+                "filter": {
+                    "name": "matrix_load_testing_tool",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'matrix-load-testing-tool'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=matrix-load-testing-tool",
+                    "--package=matrix-load-testing-tool"
+                ],
+                "filter": {
+                    "name": "matrix-load-testing-tool",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "--run",
+                "--homeserver",
+                "http://localhost:8008",
+                "--users-filename",
+                "users.local.json"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'matrix-load-testing-tool'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=matrix-load-testing-tool",
+                    "--package=matrix-load-testing-tool"
+                ],
+                "filter": {
+                    "name": "matrix-load-testing-tool",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Config.example.toml
+++ b/Config.example.toml
@@ -19,7 +19,7 @@ user_creation_retry_attempts = 5
 # Room creation retry attempts (not related to retry_request_config)
 room_creation_retry_attempts = 5
 # Room creation retry attempts for the max resource error
-room_creation_max_resource_wait_attempts
+room_creation_max_resource_wait_attempts = 5
 # Max throughput allowed for users initialization (registration and sync)
 user_creation_throughput = 10
 # Max throughput allowed for room creation

--- a/Config.toml.example
+++ b/Config.toml.example
@@ -16,7 +16,7 @@ waiting_period = 30
 retry_request_config = false
 # User creation retry attempts (not related to retry_request_config)
 user_creation_retry_attempts = 5
-# Max throughput allowed for users registration
+# Max throughput allowed for users initialization (registration and sync)
 user_creation_throughput = 10
 # Max throughput allowed for room creation
 room_creation_throughput = 20

--- a/Config.toml.example
+++ b/Config.toml.example
@@ -23,5 +23,5 @@ room_creation_throughput = 20
 # Update the client's homeserver URL with the discovery information present in the login response, if any.
 # In case of localhost, you probably want to set as false.
 respect_login_well_known = true
-# Count of useres to work with (create/erase)
+# Count of users to work with (create/erase)
 user_count = 3000

--- a/Config.toml.example
+++ b/Config.toml.example
@@ -18,6 +18,8 @@ retry_request_config = false
 user_creation_retry_attempts = 5
 # Room creation retry attempts (not related to retry_request_config)
 room_creation_retry_attempts = 5
+# Room creation retry attempts for the max resource error
+room_creation_max_resource_wait_attempts
 # Max throughput allowed for users initialization (registration and sync)
 user_creation_throughput = 10
 # Max throughput allowed for room creation

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ brew install michaeleisel/zld/zld
 
 ## Quick start
 
-1. First of all, copy the [`Config.toml.example`](Config.toml.example) file in the root directory of the project to `Config.toml`, this file will be ignored in the git repository.
+1. First of all, copy the [`Config.example.toml`](Config.example.toml) file in the root directory of the project to `Config.toml`, this file will be ignored in the git repository.
 
 1. Make sure users are available for the server you will be testing by checking the [`users.json`](users.json) file, or create them by running:
 
@@ -72,7 +72,7 @@ report:
   lost_messages: 0
 ```
 
-For more options and parameters to be configured please see `cargo run -- --help` and the [Config.toml.example](/Config.toml.example).
+For more options and parameters to be configured please see `cargo run -- --help` and the [Config.example.toml](/Config.example.toml).
 
 ## Contact me
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ rustup component add llvm-tools-preview
 brew install michaeleisel/zld/zld
 ```
 
+#### Notes
+- You might need to install XCode first from the App Store (not the Command Line Tools)
+- If Command Line Tools where already present in the system you might need to first 1) make sure XCode is in the `/Applications` directory and not the user apps one and 2) point xcode-select to the actual XCode app by using: `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
+
 ## Quick start
 
 1. First of all, copy the [`Config.toml.example`](Config.toml.example) file in the root directory of the project to `Config.toml`, this file will be ignored in the git repository.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,21 @@
+use config::ConfigError;
+
+#[derive(Debug)]
+pub enum Error {
+    StdError(Box<dyn std::error::Error>),
+    ConfigError(ConfigError),
+}
+
+impl From<Box<dyn std::error::Error>> for Error {
+    fn from(err: Box<dyn std::error::Error>) -> Error {
+        Error::StdError(err)
+    }
+}
+
+impl From<ConfigError> for Error {
+    fn from(err: ConfigError) -> Error {
+        Error::ConfigError(err)
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ impl State {
 
         let desired_users = self.config.users_per_step * self.config.total_steps;
 
-        if self.available_users < desired_users.try_into().unwrap() {
+        if (self.available_users as usize) < desired_users {
             panic!("There are only {} available users to run the test on this server, but for this test {} users are needed, please create more and try again", self.available_users, desired_users);
         }
 
@@ -382,7 +382,7 @@ impl State {
         let (tx, rx) = mpsc::channel::<Event>(100);
         let metrics = Metrics::new(rx);
         for step in 1..=self.config.total_steps {
-            println!("Running step {}", step);
+            println!("Running step {} of {}", step, self.config.total_steps);
 
             let handle = metrics.run();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,3 +87,35 @@ async fn create_users(config: Configuration) {
 async fn delete_users(_config: Configuration) {
     //TODO! Implement delete
 }
+
+#[cfg(test)]
+mod tests {
+    use config::Config;
+    use matrix_load_testing_tool::Configuration;
+
+    #[test]
+    fn validate_config_example() {
+        let config = Config::builder()
+            .add_source(config::File::with_name("Config.example"))
+            .set_override("homeserver_url", "home")
+            .unwrap()
+            .set_override("output_dir", "output")
+            .unwrap()
+            .set_override("create", true)
+            .unwrap()
+            .set_override("delete", false)
+            .unwrap()
+            .set_override("run", false)
+            .unwrap()
+            .set_override("user_count", 42)
+            .unwrap()
+            .set_override_option("users_filename", Some("users"))
+            .unwrap()
+            .build()
+            .expect("file must be present");
+
+        config
+            .try_deserialize::<Configuration>()
+            .expect("config must be deserializable");
+    }
+}

--- a/src/user.rs
+++ b/src/user.rs
@@ -378,6 +378,10 @@ impl User<Synching> {
         }
     }
 
+    /// # Panics
+    ///
+    /// - Panics if `rooms` or `available_room_ids` is empty or are disjoint
+    /// - Panics if client cannot get joined room for the selected `room_id`
     pub async fn act(&mut self) {
         let client = self.client.lock().await;
         let rooms = self.state.rooms.lock().await;
@@ -422,7 +426,7 @@ impl User<Synching> {
                 }
             }
         } else {
-            // TODO! check why this can be possible
+            panic!("cannot get joined room {}", room_id);
         }
     }
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -407,6 +407,13 @@ impl User<Synching> {
         }
     }
 
+    ///
+    /// Looks up a room with alias matching the `friendship` given and adds it to the current `state` of the user.
+    ///
+    /// # Panics
+    ///
+    /// If the `room` for the friendship given cannot be found
+    ///
     pub async fn add_friendship(&mut self, friendship: &Friendship) {
         let client = self.client.lock().await.rooms();
         if let Some(room) = client.iter().find(|room| {


### PR DESCRIPTION
Fixes #39 .

- Adds room id to user state when friendship is already available
- Panics when user act has no room, as this is a precondition
- Panics if the room selected to be used cannot be retrieved from client
- Ignores local users JSON files
- Adds `launch.json` for VS Code debugger with sample configuration
- Deriving `Debug` for `User` and `Synching`
- Minor change to logging
- Minor refactors
- Minor change to example config TOML doc
- Adds basic test to validate example config file attributes