### PR TITLE
feat: adding join errors to report

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 #[derive(Debug)]
 pub enum Event {
     Error((UserRequest, HttpError)),
-    JoinError,
+    SendMessageCancelledError,
     MessageSent(String),
     MessageReceived(String),
     RequestDuration((UserRequest, Duration)),

--- a/src/events.rs
+++ b/src/events.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 #[derive(Debug)]
 pub enum Event {
     Error((UserRequest, HttpError)),
+    JoinError,
     MessageSent(String),
     MessageReceived(String),
     RequestDuration((UserRequest, Duration)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,15 @@ impl State {
             }
 
             // Timeout is contemplated in this join_all because of the controller spawning tasks.
-            join_all(handles).await;
+            let tasks = join_all(handles).await;
+
+            // Report errors for each task that could not complete
+            for task in tasks {
+                #[allow(unused_must_use)]
+                if task.is_err() {
+                    tx.send(Event::JoinError).await;
+                }
+            }
 
             // If elapsed time of the current iteration is less than tick duration, we wait until that time.
             let elapsed = loop_start.elapsed();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,7 @@ impl State {
                 // allow unused must use as the error is expected and will be counted and reported
                 #[allow(unused_must_use)]
                 if task.is_err() {
-                    tx.send(Event::JoinError).await;
+                    tx.send(Event::SendMessageCancelledError).await;
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,7 @@ impl State {
 
             // Report errors for each task that could not complete
             for task in tasks {
+                // allow unused must use as the error is expected and will be counted and reported
                 #[allow(unused_must_use)]
                 if task.is_err() {
                     tx.send(Event::JoinError).await;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -124,7 +124,7 @@ async fn read_events(
     let mut http_errors: Vec<(UserRequest, HttpError)> = vec![];
     let mut request_times: Vec<(UserRequest, Duration)> = vec![];
     let mut messages: HashMap<String, MessageTimes> = HashMap::new();
-    let mut join_errors = 0u64;
+    let mut join_errors = 0;
 
     let mut finishing_phase = false;
 


### PR DESCRIPTION
- Adds join errors when sending messages in tasks that are cancelled and cannot be joined/finished properly