### PR TITLE
fix: room creation flow and join on invites

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,6 +27,10 @@ on:
         description: "Time to wait for all messages to be delivered"
         required: true
         default: "30"
+      execution_id:
+        description: "Used in user ID localpart"
+        required: false
+        default: "ci"
 
 env:
   CARGO_TERM_COLOR: always
@@ -77,4 +81,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --release -- -h ${{ github.event.inputs.homeserver }}
+          args: --release -- -h ${{ github.event.inputs.homeserver }} -e ${{ github.event.inputs.execution_id }}

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@ use crate::{
     text::get_random_string,
 };
 use async_channel::Sender;
-use futures::{lock::Mutex, Future};
+use futures::Future;
 use matrix_sdk::ruma::{
     api::{
         client::{
@@ -13,7 +13,7 @@ use matrix_sdk::ruma::{
             membership::join_room_by_id::v3::Request as JoinRoomRequest,
             presence::set_presence::v3::Request as UpdatePresenceRequest,
             room::create_room::v3::Request as CreateRoomRequest,
-            uiaa::{AuthData, Dummy},
+            uiaa::{AuthData, Dummy, UiaaResponse},
             Error,
         },
         error::FromHttpResponseError::{self, Server},
@@ -36,7 +36,7 @@ use matrix_sdk::{
     room::Room,
     ClientBuildError,
     Error::Http,
-    HttpError::{self, Api},
+    HttpError::{self, Api, UiaaError},
     LoopCtrl, RumaApiError,
 };
 use std::fmt::Debug;
@@ -53,7 +53,7 @@ type SyncChannel = (
 
 #[derive(Clone, Debug)]
 pub struct Client {
-    inner: Arc<Mutex<matrix_sdk::Client>>,
+    inner: Arc<matrix_sdk::Client>,
     event_notifier: Notifier,
     sync_channel: SyncChannel,
 }
@@ -91,7 +91,7 @@ impl Client {
         .expect("Couldn't create client");
         let channel = async_channel::unbounded::<SyncEvent>();
         Self {
-            inner: Arc::new(Mutex::new(inner)),
+            inner: Arc::new(inner),
             event_notifier: notifier,
             sync_channel: channel,
         }
@@ -107,7 +107,7 @@ impl Client {
         let timeout = Duration::from_secs(30);
 
         let request_config = if retry_enabled {
-            RequestConfig::new().retry_timeout(timeout)
+            RequestConfig::short_retry().retry_timeout(timeout)
         } else {
             RequestConfig::new().disable_retry().timeout(timeout)
         };
@@ -142,11 +142,11 @@ impl Client {
         )
         .await
         .expect("Couldn't create client");
-        self.inner = Arc::new(Mutex::new(client));
+        self.inner = Arc::new(client);
     }
 
     pub async fn login(&self, id: &UserId) -> LoginResult {
-        let client = self.inner.lock().await;
+        let client = &self.inner;
         let now = Instant::now();
         let response = client.login(id.localpart(), PASSWORD, None, None).await;
         self.event_notifier
@@ -176,7 +176,7 @@ impl Client {
     }
 
     pub async fn register(&self, id: &UserId) -> RegisterResult {
-        let client = self.inner.lock().await;
+        let client = &self.inner;
 
         let req = assign!(RegistrationRequest::new(), {
             username: Some(id.localpart()),
@@ -193,20 +193,25 @@ impl Client {
             .await
             .expect("channel should not be closed");
 
-        if let Err(e) = response {
-            self.event_notifier
-                .send(Event::Error((UserRequest::Login, e)))
-                .await
-                .expect("channel should not be closed");
-            RegisterResult::Failed
-        } else {
-            RegisterResult::Ok
+        match response {
+            Err(UiaaError(Server(Known(UiaaResponse::MatrixError(Error {
+                kind: ErrorKind::UserInUse,
+                ..
+            }))))) => RegisterResult::Ok,
+            Err(e) => {
+                self.event_notifier
+                    .send(Event::Error((UserRequest::Register, e)))
+                    .await
+                    .expect("channel should not be closed");
+                RegisterResult::Failed
+            }
+            Ok(_) => RegisterResult::Ok,
         }
     }
 
     /// Do initial sync and return rooms and new invites. Then register event handler for future syncs and notify events.
     pub async fn sync(&self, user_id: &UserId) -> SyncResult {
-        let client = self.inner.lock().await;
+        let client = &self.inner;
         let now = Instant::now();
         let response = client.sync_once(SyncSettings::default()).await;
         self.event_notifier
@@ -216,33 +221,32 @@ impl Client {
             )))
             .await
             .expect("channel to be open");
+        if response.is_err() {
+            if let Some(Http(e)) = response.err() {
+                self.event_notifier
+                    .send(Event::Error((UserRequest::InitialSync, e)))
+                    .await
+                    .expect("channel open");
+            }
+            return SyncResult::Failed;
+        }
+
         let (tx, _) = &self.sync_channel;
 
-        add_invite_event_handler(&client, tx, user_id).await;
-        add_room_message_event_handler(&client, tx, user_id, &self.event_notifier).await;
+        add_invite_event_handler(client, tx, user_id).await;
+        add_room_message_event_handler(client, tx, user_id, &self.event_notifier).await;
 
         let (cancel_sync, check_cancel) = async_channel::bounded::<bool>(1);
 
-        tokio::spawn(sync_until_cancel(&client, check_cancel).await);
+        tokio::spawn(sync_until_cancel(client, check_cancel).await);
 
-        match response {
-            Ok(res) => {
-                let joined_rooms = res.rooms.join.keys().cloned().collect::<Vec<_>>();
-                let invited_rooms = res.rooms.invite.keys().cloned().collect::<Vec<_>>();
-                SyncResult::Ok {
-                    joined_rooms,
-                    invited_rooms,
-                    cancel_sync,
-                }
-            }
-            Err(Http(e)) => {
-                self.event_notifier
-                    .send(Event::Error((UserRequest::Login, e)))
-                    .await
-                    .expect("channel open");
-                SyncResult::Failed
-            }
-            _ => SyncResult::Failed,
+        let res = response.unwrap();
+        let joined_rooms = res.rooms.join.keys().cloned().collect::<Vec<_>>();
+        let invited_rooms = res.rooms.invite.keys().cloned().collect::<Vec<_>>();
+        SyncResult::Ok {
+            joined_rooms,
+            invited_rooms,
+            cancel_sync,
         }
     }
 
@@ -251,7 +255,7 @@ impl Client {
     /// If room_id is not one of the joined rooms or couldn't retrieve it.
     ///
     pub async fn send_message(&self, room_id: &RoomId, message: String) {
-        let client = self.inner.lock().await;
+        let client = &self.inner;
 
         let content =
             AnyMessageLikeEventContent::RoomMessage(RoomMessageEventContent::text_plain(message));
@@ -287,15 +291,17 @@ impl Client {
         }
     }
 
-    pub async fn add_friend(&self, user_id: &UserId) {
+    pub async fn add_friend(&self, friend_id: &UserId) {
+        let client = &self.inner;
         // try to create room (maybe it already exists, in that case we ignore that)
-        let alias = user_id.localpart();
-        let invites = [user_id.to_owned()];
-        let request = assign!(CreateRoomRequest::new(), { room_alias_name: Some(alias), invite: &invites, is_direct: true });
+        let user_id = client.user_id().await.expect("user id should be present");
+        let alias = get_room_alias(&user_id, friend_id);
+        let invites = [friend_id.to_owned()];
+        let request = assign!(CreateRoomRequest::new(), { room_alias_name: Some(&alias), invite: &invites, is_direct: true });
 
         let now = Instant::now();
-        let client = self.inner.lock().await;
         let response = client.create_room(request).await;
+        log::debug!("Create room with alias {} response: {:#?}", alias, response);
         self.event_notifier
             .send(Event::RequestDuration((
                 UserRequest::CreateRoom,
@@ -310,12 +316,20 @@ impl Client {
                 ..
             }))))) => log::debug!("CreateRoom failed but it was already created"),
             Err(e) => {
+                log::debug!("CreateRoom failed! {}", e);
                 self.event_notifier
                     .send(Event::Error((UserRequest::CreateRoom, e)))
                     .await
                     .expect("channel should not be closed");
             }
-            Ok(_) => {}
+            Ok(response) => {
+                log::debug!("room created and invite sent to {}!", friend_id);
+                self.sync_channel
+                    .0
+                    .send(SyncEvent::RoomCreated(response.room_id))
+                    .await
+                    .expect("channel to be open");
+            }
         }
     }
 
@@ -336,7 +350,7 @@ impl Client {
         Request: OutgoingRequest + Debug,
         HttpError: From<FromHttpResponseError<Request::EndpointError>>,
     {
-        let client = self.inner.lock().await;
+        let client = &self.inner;
         let now = Instant::now();
         let response = client.send(request, None).await;
         self.event_notifier
@@ -359,7 +373,7 @@ async fn sync_until_cancel(
     client: &matrix_sdk::Client,
     check_cancel: async_channel::Receiver<bool>,
 ) -> impl Future<Output = ()> {
-    // we are not cloning the mutex to avoid locking it forever
+    // client state is held in an `Arc` so the `Client` can be cloned freely.
     let client = client.clone();
     async move {
         client
@@ -454,9 +468,6 @@ async fn on_room_message(
             if event.sender.localpart() == user_id.localpart() {
                 return;
             }
-            room.read_receipt(&event.event_id)
-                .await
-                .expect("can send read receipt");
 
             log::debug!(
                 "Message received! next time user {} will have someone to respond :D",
@@ -473,4 +484,10 @@ async fn on_room_message(
                 .expect("channel open");
         }
     }
+}
+
+fn get_room_alias(first: &UserId, second: &UserId) -> String {
+    let mut names = vec![first.localpart(), second.localpart()];
+    names.sort();
+    names.join("-")
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -8,20 +8,14 @@ use serde_with::DurationSeconds;
 use std::time::Duration;
 
 /// This function returns homeserver domain and url, ex:
-///  - get_homeserver_url("matrix.domain.com") => ("matrix.domain.com", "https://matrix.domain.com")
-///  - get_homeserver_url("synapse.domain.com") => ("domain.com", "https://matrix.domain.com")
-pub fn get_homeserver_url(homeserver: &str, default_protocol: Option<&str>) -> (String, String) {
+///  - get_homeserver_url("matrix.domain.com") => "https://matrix.domain.com"
+pub fn get_homeserver_url(homeserver: &str, default_protocol: Option<&str>) -> String {
     let regex = Regex::new(r"https?://").unwrap();
     if regex.is_match(homeserver) {
-        let parts: Vec<&str> = regex.splitn(homeserver, 2).collect();
-        let domain = parts[1].to_string().replace("synapse.", "");
-        (domain, homeserver.to_string())
+        homeserver.to_string()
     } else {
         let protocol = default_protocol.unwrap_or("https");
-        (
-            homeserver.to_string().replace("synapse.", ""),
-            format!("{protocol}://{homeserver}"),
-        )
+        format!("{protocol}://{homeserver}")
     }
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -9,14 +9,19 @@ use std::time::Duration;
 
 /// This function returns homeserver domain and url, ex:
 ///  - get_homeserver_url("matrix.domain.com") => ("matrix.domain.com", "https://matrix.domain.com")
+///  - get_homeserver_url("synapse.domain.com") => ("domain.com", "https://matrix.domain.com")
 pub fn get_homeserver_url(homeserver: &str, default_protocol: Option<&str>) -> (String, String) {
     let regex = Regex::new(r"https?://").unwrap();
     if regex.is_match(homeserver) {
         let parts: Vec<&str> = regex.splitn(homeserver, 2).collect();
-        (parts[1].to_string(), homeserver.to_string())
+        let domain = parts[1].to_string().replace("synapse.", "");
+        (domain, homeserver.to_string())
     } else {
         let protocol = default_protocol.unwrap_or("https");
-        (homeserver.to_string(), format!("{protocol}://{homeserver}"))
+        (
+            homeserver.to_string().replace("synapse.", ""),
+            format!("{protocol}://{homeserver}"),
+        )
     }
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -44,6 +44,10 @@ pub struct Args {
 
     /// Output folder for reports
     output: Option<String>,
+
+    /// Execution ID to be used as part of the ID (as localpart)
+    #[clap(short, long, value_parser)]
+    execution_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -94,6 +98,7 @@ impl Config {
             .set_override_option("simulation.users_per_tick", args.users_per_tick)?
             .set_override_option("simulation.output", args.output)?
             .set_default("simulation.execution_id", time_now().to_string())?
+            .set_override_option("simulation.execution_id", args.execution_id)?
             .build()?;
 
         log::debug!("Config: {:#?}", config);

--- a/src/events.rs
+++ b/src/events.rs
@@ -38,6 +38,7 @@ pub enum Event {
 #[derive(Clone, Debug)]
 pub enum SyncEvent {
     Invite(OwnedRoomId),
+    RoomCreated(OwnedRoomId),
     Message(OwnedRoomId, String),
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -45,14 +45,14 @@ impl User {
         Self {
             id,
             client: Client::new(notifier, config).await,
-            state: State::Unauthenticated,
+            state: State::Unregistered,
         }
     }
 
     pub async fn act(&mut self, context: &Context) {
         match &self.state {
-            State::Unauthenticated => self.log_in().await,
             State::Unregistered => self.register().await,
+            State::Unauthenticated => self.log_in().await,
             State::LoggedIn => self.sync().await,
             State::Sync { .. } => self.socialize(context).await,
             State::LoggedOut => self.restart(&context.config).await,


### PR DESCRIPTION
## Description

- Fixes room aliases
- Add room to the list when created
- Improve Error handling
- Avoid picking the same user more than once in a tick
- Avoid users adding themselves as friend
- Better debug logging

Fixes #69 