### PR TITLE
feat: custom sync loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
 
 [[package]]
+name = "bichannel"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4bdf5473d36d166934ddefbedab84ad123ba887d2dd16eb2e1a036c484c213b"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
 dependencies = [
  "cache-padded",
 ]
@@ -533,6 +542,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1343,7 +1362,7 @@ name = "matrix-reloaded"
 version = "0.1.0"
 dependencies = [
  "async-channel",
- "async-trait",
+ "bichannel",
  "chrono",
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ tokio-context = "0.1.3"
 chrono = "0.4.19"
 matrix-sdk = "0.5.0"
 matrix-sdk-base = "0.5.1"
-async-trait = "0.1.53"
 async-channel = "1.6.1"
+bichannel = { version="0.0.4", features = ["crossbeam"] }
 tokio-graceful-shutdown = "0.10"
 miette = { version = "4.4", features = ["fancy"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod events;
 pub mod progress;
 mod report;
 pub mod simulation;
+mod sync;
 mod text;
 mod time;
 mod user;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,125 @@
+use bichannel::Channel;
+use futures::Future;
+use matrix_sdk::{config::SyncSettings, deserialized_responses::SyncResponse, LoopCtrl};
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+pub enum SyncResult {
+    Ok(Box<SyncResponse>),
+    Failed(usize),
+}
+
+#[derive(Debug)]
+pub enum SyncLoopMessage {
+    LogOut,
+    StopSync,
+}
+
+pub type SyncLoopChannel = Channel<SyncLoopMessage, SyncLoopMessage>;
+pub type SyncLoopChannels = (SyncLoopChannel, Channel<SyncLoopMessage, SyncLoopMessage>);
+
+/// Repeatedly call sync to synchronize the client state with the server.
+///
+/// # Arguments
+///
+/// * `sync_settings` - Settings for the sync call. *Note* that those
+///   settings will be only used for the first sync call. See the argument
+///   docs for [`Client::sync_once`] for more info.
+///
+/// * `callback` - A callback that will be called every time a
+///   response has been fetched from the server. The callback must return a
+///   boolean which signalizes if the method should stop syncing. If the
+///   callback returns `LoopCtrl::Continue` the sync will continue, if the
+///   callback returns `LoopCtrl::Break` the sync will be stopped.
+///
+pub async fn sync_with_callback<C>(client: &matrix_sdk::Client, callback: impl Fn(SyncResult) -> C)
+where
+    C: Future<Output = LoopCtrl>,
+{
+    let mut last_sync_time: Option<Instant> = None;
+    let mut sync_settings = SyncSettings::default();
+
+    if let Some(token) = client.sync_token().await {
+        sync_settings = sync_settings.token(token);
+    }
+
+    let mut attempt = 0;
+    loop {
+        let response = client.sync_once(sync_settings.clone()).await;
+
+        let result = match response {
+            Ok(r) => {
+                attempt = 0;
+                sync_settings = sync_settings.token(r.next_batch.clone());
+                SyncResult::Ok(Box::new(r))
+            }
+            Err(e) => {
+                attempt += 1;
+                log::debug!("sync failed ({} time/s): {:#?}", attempt, e);
+                sleep(Duration::from_secs(1)).await;
+                SyncResult::Failed(attempt)
+            }
+        };
+        if callback(result).await == LoopCtrl::Break {
+            return;
+        }
+
+        delay_sync(&mut last_sync_time).await
+    }
+}
+
+async fn delay_sync(last_sync_time: &mut Option<Instant>) {
+    let now = Instant::now();
+
+    // If the last sync happened less than a second ago, sleep for a
+    // while to not hammer out requests if the server doesn't respect
+    // the sync timeout.
+    if let Some(t) = last_sync_time {
+        if now - *t <= Duration::from_secs(1) {
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    *last_sync_time = Some(now);
+}
+///
+/// Repeatedly call sync to synchronize the client state with the server.
+///
+/// It uses `sync_loop_channel` to listen user log out action,
+/// or notify user to log out after 3 attempts of sync with failures.
+/// If one of those happen, it will break the sync loop.
+///  
+pub async fn sync(
+    client: &matrix_sdk::Client,
+    sync_loop_channel: SyncLoopChannel,
+) -> impl Future<Output = ()> {
+    // client state is held in an `Arc` so the `Client` can be cloned freely.
+    let client = client.clone();
+    async move {
+        sync_with_callback(&client, {
+            |sync_result| {
+                let sync_loop_channel = sync_loop_channel.clone();
+                async move {
+                    // user sent the stop sync, so we break the loop
+                    if let Ok(SyncLoopMessage::StopSync) = sync_loop_channel.try_recv() {
+                        return LoopCtrl::Break;
+                    }
+                    match sync_result {
+                        SyncResult::Ok(_) => {}
+                        SyncResult::Failed(attempts) => {
+                            if attempts >= 3 {
+                                // notify user is not in sync any more and break the loop
+                                sync_loop_channel
+                                    .send(SyncLoopMessage::LogOut)
+                                    .expect("channel to be open");
+                                return LoopCtrl::Break;
+                            }
+                        }
+                    }
+                    LoopCtrl::Continue
+                }
+            }
+        })
+        .await;
+    }
+}


### PR DESCRIPTION
## Description

When several sync requests fail, the user state changes to `LoggedOut` and breaks the sync loop. The idea behind this is that the home server may start failing and we want to see it reflected in user states.