### PR TITLE
feat: add user lifetimes (ticks to live) depending on random selection

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -35,6 +35,10 @@ on:
         description: "User: probability to act (0-100)"
         required: false
         default: "100"
+      probability_for_short_lifes:
+        description: "User: probability to have a short life (0-100)"
+        required: false
+        default: "50"
 
 env:
   CARGO_TERM_COLOR: always
@@ -88,6 +92,12 @@ jobs:
           file: "configuration.toml"
           key: "simulation.probability_to_act"
           value: ${{ github.event.inputs.probability_to_act }}
+      - name: Set probability_for_short_lifes
+        uses: ciiiii/toml-editor@1.0.0
+        with:
+          file: "configuration.toml"
+          key: "simulation.probability_for_short_lifes"
+          value: ${{ github.event.inputs.probability_for_short_lifes }}
       - uses: actions-rs/cargo@v1
         with:
           command: run

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,14 +110,12 @@ impl Client {
             RequestConfig::new().disable_retry().timeout(timeout)
         };
 
-        let client = matrix_sdk::Client::builder()
+        matrix_sdk::Client::builder()
             .request_config(request_config)
             .homeserver_url(homeserver)
             .respect_login_well_known(respect_login_well_known)
             .build()
-            .await;
-
-        client
+            .await
     }
 
     pub async fn read_sync_events(&self) -> Vec<SyncEvent> {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -77,7 +77,7 @@ pub struct Simulation {
     pub output: String,
     pub execution_id: String,
     pub probability_to_act: usize,
-    pub probability_for_short_lives: usize,
+    pub probability_for_short_lifes: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -51,6 +51,9 @@ pub struct Args {
 
     /// Probability of a user to act on a tick. Default is 100 (%).
     probability_to_act: Option<i64>,
+
+    /// Probability of a user to have a short life. Should be a number between 0 and 100. Default is 50 (%).
+    probability_for_short_lifes: Option<i64>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -74,6 +77,7 @@ pub struct Simulation {
     pub output: String,
     pub execution_id: String,
     pub probability_to_act: usize,
+    pub probability_for_short_lives: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -102,8 +106,14 @@ impl Config {
             .set_override_option("simulation.users_per_tick", args.users_per_tick)?
             .set_override_option("simulation.output", args.output)?
             .set_default("simulation.execution_id", time_now().to_string())?
+            .set_default("simulation.probability_to_act", 100.)?
+            .set_default("simulation.probability_for_short_lifes", 50.)?
             .set_override_option("simulation.execution_id", args.execution_id)?
             .set_override_option("simulation.probability_to_act", args.probability_to_act)?
+            .set_override_option(
+                "simulation.probability_for_short_lifes",
+                args.probability_for_short_lifes,
+            )?
             .build()?;
 
         log::debug!("Config: {:#?}", config);

--- a/src/user.rs
+++ b/src/user.rs
@@ -317,7 +317,7 @@ async fn pick_random_room(rooms: &RwLock<Vec<OwnedRoomId>>) -> Option<OwnedRoomI
 /// so users can be short or long lived.
 fn get_ticks_to_live(config: &Config) -> usize {
     let mut rng = rand::thread_rng();
-    let short_lived = rng.gen_bool(config.simulation.probability_to_act as f64 / 100.);
+    let short_lived = rng.gen_bool(config.simulation.probability_for_short_lifes as f64 / 100.);
     match short_lived {
         true => max(config.simulation.ticks / 100, 5),
         false => max(config.simulation.ticks / 10, 10),

--- a/src/user.rs
+++ b/src/user.rs
@@ -264,7 +264,7 @@ impl User {
         log::debug!("user '{}' act => {}", self.localpart, "LOG OUT");
         cancel_sync.send(true).await.expect("channel open");
         self.state = State::LoggedOut;
-        self.localpart += "*";
+        self.localpart += "_";
     }
 
     async fn update_status(&self) {
@@ -317,7 +317,7 @@ async fn pick_random_room(rooms: &RwLock<Vec<OwnedRoomId>>) -> Option<OwnedRoomI
 /// so users can be short or long lived.
 fn get_ticks_to_live(config: &Config) -> usize {
     let mut rng = rand::thread_rng();
-    let short_lived = rng.gen_bool(1. / 2.);
+    let short_lived = rng.gen_bool(config.simulation.probability_to_act as f64 / 100.);
     match short_lived {
         true => max(config.simulation.ticks / 100, 5),
         false => max(config.simulation.ticks / 10, 10),


### PR DESCRIPTION
## Description

Users now have different `ticks_to_live` based on a random selection, and once they log out the user ID will change so next time it logs ins as another user.

### Todo
- [ ] Check `*` is a valid character for users ID' localpart

Solves #75 