### PR TITLE
fix: dms not identified as dm

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -291,7 +291,7 @@ impl Client {
         let user_id = client.user_id().await.expect("user id should be present");
         let alias = get_room_alias(&user_id, friend_id);
         let invites = [friend_id.to_owned()];
-        let request = assign!(CreateRoomRequest::new(), { room_alias_name: Some(&alias), invite: &invites, is_direct: true });
+        let request = assign!(CreateRoomRequest::new(), { room_alias_name: Some(&alias), invite: &invites, is_direct: true, preset: Some(RoomPreset::TrustedPrivateChat) });
         let response = self
             .instrument(UserRequest::CreateRoom, || async {
                 client.create_room(request).await

--- a/src/client.rs
+++ b/src/client.rs
@@ -322,7 +322,7 @@ impl Client {
         let user_id = client.user_id().await.expect("user id should be present");
         let alias = get_room_alias(&user_id, friend_id);
         let invites = [friend_id.to_owned()];
-        let request = assign!(CreateRoomRequest::new(), { room_alias_name: Some(&alias), invite: &invites, is_direct: true });
+        let request = assign!(CreateRoomRequest::new(), { room_alias_name: Some(&alias), invite: &invites, is_direct: true, preset: Some(RoomPreset::TrustedPrivateChat) });
 
         let now = Instant::now();
         let response = client.create_room(request).await;

--- a/src/client.rs
+++ b/src/client.rs
@@ -578,16 +578,17 @@ async fn on_room_message(
                 return;
             }
 
-            log::debug!(
-                "Message received! next time user {} will have someone to respond :D",
-                user_id
-            );
-
             let message_type = if is_channel(&room) {
                 RoomType::Channel
             } else {
                 RoomType::DirectMessage
             };
+
+            log::debug!(
+                "Message {:?} received! next time user {} will have someone to respond :D",
+                message_type,
+                user_id
+            );
 
             sender
                 .send(SyncEvent::MessageReceived(


### PR DESCRIPTION
### Issue
We found a bug that caused not identify DM as a private room after its creation. So, it ended up that a DM was mixed with Channels. 

**Explanation:**
I came across this bug, trying to find another bug. I disabled the `channel_load` on my local (I think the first time I do this) and this bug turned up. A DM room was created but at the same time, this room was added as a Channel to the global simulation so that other users could join this "channel" (actually was not a channel)

### Solution
Change the event that listened to the room creation. Now the script listens to the "room join rules" event because the created room doesn't have its state updated after the creation. cc @guidota 