### PR TITLE
fix: user responding messages in channels when feature is disabled

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -625,16 +625,17 @@ async fn on_room_message(
                 return;
             }
 
-            log::debug!(
-                "Message received! next time user {} will have someone to respond :D",
-                user_id
-            );
-
             let message_type = if is_channel(&room) {
                 RoomType::Channel
             } else {
                 RoomType::DirectMessage
             };
+
+            log::debug!(
+                "Message {:?} received! next time user {} will have someone to respond :D",
+                message_type,
+                user_id
+            );
 
             sender
                 .send(SyncEvent::MessageReceived(


### PR DESCRIPTION
this PR:
- add a check before responding to a message if it's a channel message and channel load is disabled. 
anyway, probably this was not a bug and the check is not too necessary due to the #98 fix. 